### PR TITLE
Removed template argument from std::lock_guard

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -119,7 +119,7 @@ static THD_FUNCTION(spiThread2, arg) {
       // queue CAN frame for transmission in thread-safe block
       {
         // Lock from simultaneous thread access
-        std::lock_guard<chibios_rt::Mutex> lock(CAN_BUS_MUT);
+        std::lock_guard lock(CAN_BUS_MUT);
 
         // queue CAN message for one set of 7 cell modules
         (CAN_BUS).queueTxMessage(cellTempMessage);
@@ -141,7 +141,7 @@ static THD_FUNCTION(canTxThreadFunc, arg) {
   while (true) {
     {
       // Lock from simultaneous thread access
-      std::lock_guard<chibios_rt::Mutex> lock(CAN_BUS_MUT);
+      std::lock_guard lock(CAN_BUS_MUT);
       // Process all messages to transmit from the message transmission queue
       (CAN_BUS).processTxMessages();
     }
@@ -165,7 +165,7 @@ static THD_FUNCTION(canRxThreadFunc, arg) {
       continue;
     }
     {
-      std::lock_guard<chibios_rt::Mutex> lock(CAN_BUS_MUT);
+      std::lock_guard lock(CAN_BUS_MUT);
       (CAN_BUS).processRxMessages();
     }
   }
@@ -184,7 +184,7 @@ static THD_FUNCTION(heartbeatThreadFunc, arg) {
     // enqueue heartbeat message to g_canTxQueue
     const HeartbeatMessage heartbeatMessage(kNodeIdCellTemp);
     {
-      std::lock_guard<chibios_rt::Mutex> lock(CAN_BUS_MUT);
+      std::lock_guard lock(CAN_BUS_MUT);
       (CAN_BUS).queueTxMessage(heartbeatMessage);
     }
     // transmit node's (self) heartbeat every 1s


### PR DESCRIPTION
C++17 automatically deduces template arguments for constructors.