### PR TITLE
Fault io

### DIFF
--- a/CanOpenPdo.cpp
+++ b/CanOpenPdo.cpp
@@ -4,6 +4,23 @@
 
 #include <cstring>
 
+FaultStatusesMessage::FaultStatusesMessage(uint8_t tempDidFault,
+                                           uint8_t bmsDidFault,
+                                           uint8_t imdDidFault) {
+  IDE = CAN_IDE_EXT;
+  EID = kSysIdFs | kNodeIdCellTemp | kFuncIdFaultStatuses;
+  RTR = CAN_RTR_DATA;
+  DLC = 1;  // num data bytes in frame
+
+  // clean fault statuses in case more than LS bit set
+  tempDidFault = tempDidFault & 0x1;
+  bmsDidFault = bmsDidFault & 0x1;
+  imdDidFault = imdDidFault & 0x1;
+
+  // copy passed data into frame's data byte
+  data8[0] = (tempDidFault << 2) | (bmsDidFault << 1) | (imdDidFault);
+}
+
 CellTempMessage::CellTempMessage(uint32_t adcChipId,
                                  uint8_t cellModuleReadings[7]) {
   IDE = CAN_IDE_EXT;

--- a/CanOpenPdo.h
+++ b/CanOpenPdo.h
@@ -9,6 +9,8 @@
 
 // COB-IDs: MAX LENGTH of 12 bits, only the LSB 12 should be used
 // IDs specified in format 0x<system-id><node-id><function-id>
+// NOTE: The constexprs below are now bit-shifted, there OR'd as-is so
+//       the values must be in the correct hex digit.
 // System IDs: 6 = FS System
 // Node IDs:
 //   1 = Primary Controller, (node 3)
@@ -19,6 +21,7 @@
 //     3 = ADC Chip 2 Reading
 //     4 = ADC Chip 3 Reading
 //     5 = ADC Chip 4 Reading
+//     6 = Fault Statuses for Temp, BMS, and IMD
 // Universal Function IDs:
 //   1 = Heartbeat
 constexpr uint32_t kSysIdFs = 0x600;
@@ -26,6 +29,7 @@ constexpr uint32_t kNodeIdPrimary = 0x010;
 constexpr uint32_t kNodeIdSecondary = 0x020;
 constexpr uint32_t kNodeIdCellTemp = 0x030;
 constexpr uint32_t kFuncIdCellTempAdc[4] = {0x002, 0x003, 0x004, 0x005};
+constexpr uint32_t kFuncIdFaultStatuses = 0x006;
 
 constexpr uint32_t kCobIdTPDO5 = 0x241;  // including throttle voltage payload
 constexpr uint32_t kCobIdNode3Heartbeat = 0x611;  // changed from 0x003
@@ -43,6 +47,12 @@ struct HeartbeatMessage : public CANTxFrame {
 
 struct CellTempMessage : public CANTxFrame {
   CellTempMessage(uint32_t adcChipId, uint8_t cellModuleReadings[7]);
+};
+
+struct FaultStatusesMessage : public CANTxFrame {
+  FaultStatusesMessage(uint8_t tempFaultStatus,
+                       uint8_t bmsFaultStatus,
+                       uint8_t imdFaultStatus);
 };
 
 struct ThrottleMessage : public CANTxFrame {

--- a/Main.cpp
+++ b/Main.cpp
@@ -142,7 +142,12 @@ static THD_FUNCTION(spiThread2, arg) {
     }
 
     // check for fault status of BMS and IMD digital inputs
-    // ...
+    if (!bmsDidFault && palReadLine(LINE_ARD_D4) == PAL_HIGH) {
+      bmsDidFault = true;
+    }
+    if (!imdDidFault && palReadLine(LINE_ARD_D5) == PAL_HIGH) {
+      imdDidFault = true;
+    }
 
     // output a fault packet containing fault states of temp, BMS, and IMD
     // ...
@@ -231,8 +236,10 @@ int main() {
   chibios_rt::Mutex spiBusMut;
 
   // fault signal I/O pins
-  palSetLineMode(LINE_ARD_D3, PAL_MODE_OUTPUT_PUSHPULL);  // mode
-  palWriteLine(LINE_ARD_D3, PAL_LOW);  // init value
+  palSetLineMode(LINE_ARD_D3, PAL_MODE_OUTPUT_PUSHPULL);  // temp mode
+  palWriteLine(LINE_ARD_D3, PAL_LOW);  // init temp fault value
+  palSetLineMode(LINE_ARD_D4, PAL_MODE_INPUT);  // BMS mode
+  palSetLineMode(LINE_ARD_D5, PAL_MODE_INPUT);  // IMD mode
 
   // create void* compatible obj
   std::vector<void*> args = {&canBus, &canBusMut};

--- a/Main.cpp
+++ b/Main.cpp
@@ -117,8 +117,8 @@ static THD_FUNCTION(spiThread2, arg) {
         cellModuleReadings[channelIndex] = adcToTemp(rxbuf);
 
         // set cell temp fault high if threshold was crossed
-        if (cellModuleReadings[channelIndex] > faultTempValue
-            && !cellTempDidFault) {
+        if (!cellTempDidFault
+            && cellModuleReadings[channelIndex] > faultTempValue) {
           palWriteLine(LINE_ARD_D3, PAL_HIGH);  // init value
           cellTempDidFault = true;
         }


### PR DESCRIPTION
Added support for outputting temp system fault signal and monitoring BMS and IMD fault signals. A CAN message is transmitted with the fault statuses of the temp system, BMS, and IMD in the LS three bits, respectively.